### PR TITLE
Swap GPIO pins to Plasma header defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,6 @@ sudo pip2 install plasmalights
 
 ### Using Plasma Daemon
 
-Note: If you're using Picade Player X you should edit daemon/etc/systemd/system/plasma.service and change the output device option from `-o GPIO:14:15` to `-o SERIAL:/dev/ttyACM0`. If you're using Unicorn HAT or pHAT you should use `-o WS281X:WS2812:18:0`.
-
 To install the Plasma daemon you should clone this repository, navigate to the "daemon" directory and run the installer:
 
 ```
@@ -78,6 +76,14 @@ git clone https://github.com/pimoroni/plasma
 cd plasma/daemon
 sudo ./install
 ```
+
+---
+
+Note: If you're using Picade Player X you should edit daemon/etc/systemd/system/plasma.service and change the output device option from `-o GPIO:15:14` to `-o SERIAL:/dev/ttyACM0`. If you're using Unicorn HAT or pHAT you should use `-o WS281X:WS2812:18:0`.
+
+If you're using GPIO on a Picade HAT you can adjust the pins accordingly using `-o GPIO:<data>:<clock>` where data and clock are valid BCM pins. If you're using the old Plasma/Hack header you may need to swap from `-o GPIO:15:14` to `-o GPIO:14:15` depending on how your connections are wired.
+
+---
 
 The Plasma daemon installer installs two programs onto your Raspberry Pi. `plasma` itself and a tool called `plasmactl` you can use to install and switch lighting effects. Plasma runs as a service on your system.
 

--- a/daemon/etc/systemd/system/plasma.service
+++ b/daemon/etc/systemd/system/plasma.service
@@ -5,7 +5,7 @@ After=local-fs.target
 
 [Service]
 # Change -o to SERIAL:/dev/ttyACM0 for Plasma via Picade Player X
-ExecStart=/usr/bin/plasma -d -o GPIO:14:15
+ExecStart=/usr/bin/plasma -d -o GPIO:15:14
 Restart=on-failure
 Type=forking
 PIDFile=/var/run/plasma.pid

--- a/daemon/usr/bin/plasma
+++ b/daemon/usr/bin/plasma
@@ -146,7 +146,8 @@ def options():
                       help="set plasma LED update framerate")
     parser.add_option("-l", "--lights", action="store", dest="lights", type="int", default=LIGHTS,
                       help="set number of lights in your plasma chain")
-    parser.add_option("-o", "--device", default="GPIO:14:15")
+    parser.add_option("-o", "--device", default="GPIO:15:14",
+                      help="set output device, default is GPIO, BCM15 = Data, BCM14 = Clock")
     return parser.parse_args()[0]
 
 


### PR DESCRIPTION
Ealier guides referred to the BTN7 and BTN8 pins on Picade HAT, which have now been superceded by the plug-and-play Plasma connector. Unfortunately the Plasma connector pins are reversed compared to previous guides (this is fine, the order is pretty much arbitrary on the original guides/connector) and the pin order in this software- this PR changes the pins in Plasma to match those of the physical connector. This comes at the expense of an incompatibility with some existing setups, however in most cases the user can simply swap the Data/Clock connections around or- if they don't wish to open their Picade or modify their project- update the systemd unit with the correct pinout. (Granted this only applies to anyone who tries to reinstall/update after this PR has been merged.)