### PR TITLE
Add multi-daemon support

### DIFF
--- a/daemon/usr/bin/plasma
+++ b/daemon/usr/bin/plasma
@@ -6,6 +6,7 @@ import signal
 import os
 import sys
 import threading
+import re
 from datetime import datetime
 from optparse import OptionParser
 
@@ -15,10 +16,12 @@ FPS = 30
 LIGHTS = 10
 DEBUG = False
 
-# Log & PID files
-PID_FILE = "/var/run/plasma.pid"
-LOG_FILE = "/var/log/plasma.log"
-ERR_FILE = "/var/log/plasma.err"
+# Log & PID files - we're moving these to main(), so they can reflect the fifo name
+FIFO_FILE = ""
+PID_FILE = ""
+LOG_FILE = ""
+ERR_FILE = ""
+
 
 
 stopped = threading.Event()
@@ -57,7 +60,25 @@ class FIFO():
 
 
 def main():
+    global FIFO_FILE
+    global PID_FILE
+    global LOG_FILE
+    global ERR_FILE
+
     opts = options()
+
+    pipename = re.sub(r'^.*/', '', opts.pipe)
+    if (pipename == "plasma"):
+      FIFO_FILE = "/tmp/plasma"
+      PID_FILE = "/var/run/plasma.pid"
+      LOG_FILE = "/var/log/plasma.log"
+      ERR_FILE = "/var/log/plasma.err"
+    else:
+      FIFO_FILE = "/tmp/plasma-{}".format(pipename)
+      PID_FILE = "/var/run/plasma-{}.pid".format(pipename)
+      LOG_FILE = "/var/log/plasma-{}.log".format(pipename)
+      ERR_FILE = "/var/log/plasma-{}.err".format(pipename)
+    log("Plasma input pipe: {}".format(FIFO_FILE))
 
     if opts.daemonize:
         fork()
@@ -70,12 +91,10 @@ def main():
         daemon='background' if opts.daemonize else 'foreground',
         fps=opts.fps))
 
-    log("Plasma input pipe: {}".format(opts.pipe))
-
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
 
-    with FIFO(opts.pipe) as fifo:
+    with FIFO(FIFO_FILE) as fifo:
         r, g, b = 0, 0, 0
         pattern, pattern_w, pattern_h, pattern_meta = load_pattern("default")
         alpha = pattern_meta['alpha']
@@ -147,8 +166,8 @@ def options():
                       help="set number of lights in your plasma chain")
     parser.add_option("-o", "--device", default="GPIO:15:14",
                       help="set output device, default is GPIO, BCM15 = Data, BCM14 = Clock")
-    parser.add_option("-p", "--pipe", default="/tmp/plasma",
-                      help="set pipe used for client process communication, default /tmp/plasma")
+    parser.add_option("-p", "--pipe", default="plasma",
+                      help="set pipe used for client process communication, default plasma to create pipe /tmp/plasma. Also sets logfile and pidfile names.")
     return parser.parse_args()[0]
 
 

--- a/daemon/usr/bin/plasma
+++ b/daemon/usr/bin/plasma
@@ -10,7 +10,6 @@ from datetime import datetime
 from optparse import OptionParser
 
 # Application Defaults
-PIPE_FILE = "/tmp/plasma"
 PATTERNS = "/etc/plasma/"
 FPS = 30
 LIGHTS = 10
@@ -71,12 +70,12 @@ def main():
         daemon='background' if opts.daemonize else 'foreground',
         fps=opts.fps))
 
-    log("Plasma input pipe: {}".format(PIPE_FILE))
+    log("Plasma input pipe: {}".format(opts.pipe))
 
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
 
-    with FIFO(PIPE_FILE) as fifo:
+    with FIFO(opts.pipe) as fifo:
         r, g, b = 0, 0, 0
         pattern, pattern_w, pattern_h, pattern_meta = load_pattern("default")
         alpha = pattern_meta['alpha']
@@ -148,6 +147,8 @@ def options():
                       help="set number of lights in your plasma chain")
     parser.add_option("-o", "--device", default="GPIO:15:14",
                       help="set output device, default is GPIO, BCM15 = Data, BCM14 = Clock")
+    parser.add_option("-p", "--pipe", default="/tmp/plasma",
+                      help="set pipe used for client process communication, default /tmp/plasma")
     return parser.parse_args()[0]
 
 

--- a/daemon/usr/bin/plasma
+++ b/daemon/usr/bin/plasma
@@ -64,6 +64,7 @@ def main():
     global PID_FILE
     global LOG_FILE
     global ERR_FILE
+    global pipename
 
     opts = options()
 
@@ -144,7 +145,13 @@ def main():
 
 
 def load_pattern(pattern_name):
-    pattern_file = os.path.join(PATTERNS, "{}.png".format(pattern_name))
+    if (pattern_name == "default"):
+        pattern_file = os.path.join(PATTERNS, "default-{}.png".format(pipename))
+        if not os.path.isfile(pattern_file):
+            pattern_file = os.path.join(PATTERNS, "{}.png".format(pattern_name))
+    else:
+        pattern_file = os.path.join(PATTERNS, "{}.png".format(pattern_name))
+
     if os.path.isfile(pattern_file):
         r = png.Reader(file=open(pattern_file, 'rb'))
         pattern_w, pattern_h, pattern, pattern_meta = r.read()

--- a/daemon/usr/bin/plasmactl
+++ b/daemon/usr/bin/plasmactl
@@ -4,10 +4,10 @@ if [ "$1" == "--help" ] || [ "$1" == "" ]; then
 	cat <<__EOF__
 
 Usage:
-    $0 [-p|--pipe] <r> <g> <b> - Display an RGB colour (all values 0-255)
-    $0 [-p|--pipe] <image name> - Display an image-based animation
+    $0 [-p|--pipe PATH] <r> <g> <b> - Display an RGB colour (all values 0-255)
+    $0 [-p|--pipe PATH] <image name> - Display an image-based animation
     from /etc/plasma
-    $0 [-p|--pipe] fps <fps> - Set the update framerate
+    $0 [-p|--pipe PATH] fps <fps> - Set the update framerate
     $0 --install <filename> - Install an animation file
     $0 --list - List available animations
 

--- a/daemon/usr/bin/plasmactl
+++ b/daemon/usr/bin/plasmactl
@@ -1,8 +1,28 @@
 #!/bin/bash
 
 if [ "$1" == "--help" ] || [ "$1" == "" ]; then
-	echo -e "\nUsage:\n    $0 <r> <g> <b> - Display an RGB colour (all values 0-255)\n    $0 <image name> - Display an image-based animation from /etc/plasma\n    $0 fps <fps> - Set the update framerate\n    $0 --install <filename> - Install an animation file\n    $0 --list - List available animations\n"
+	cat <<__EOF__
+
+Usage:
+    $0 [-p|--pipe] <r> <g> <b> - Display an RGB colour (all values 0-255)
+    $0 [-p|--pipe] <image name> - Display an image-based animation
+    from /etc/plasma
+    $0 [-p|--pipe] fps <fps> - Set the update framerate
+    $0 --install <filename> - Install an animation file
+    $0 --list - List available animations
+
+FIFO specification:
+    $0 -p|--pipe /path/to/pipe <cmd>
+      - Communicate with plasma daemon via FIFO /path/to/pipe
+__EOF__
 	exit 0
+fi
+
+pipe=/tmp/plasma
+if [ "$1" == "-p" -o "$1" == "--pipe" ]; then
+  pipe="$2"
+  shift 2
+  echo "Set FIFO path to $pipe"
 fi
 
 if [ "$1" == "--list" ]; then
@@ -24,8 +44,8 @@ if [ "$1" == "--install" ]; then
 	fi
 fi
 
-if [ -p "/tmp/plasma" ]; then
-	echo "$@" > /tmp/plasma
+if [ -p "$pipe" ]; then
+	echo "$@" > "$pipe"
 else
-	echo -e "\n/tmp/plasma not found.\nPlasma daemon not running?\n"
+	echo -e "\n${pipe} not found.\nPlasma daemon not running?\n"
 fi


### PR DESCRIPTION
This is code I wrote earlier this year for multi-daemon support for my arcade build.

It supports per-player plasma daemons, so that players can have individual plasma patterns.  In my case, it's working on the Picade X HAT and a Player X board, but this should work on multiple Player X boards just as well.

The modifications here are simple - instead of relying on a statically defined FIFO and pidfile, let these be set on a per-daemon basis.  The plasmactl client also has minor modifications to support specifying an alternate FIFO to talk to.